### PR TITLE
feat: get versions from pyenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vfox-python
-Python plugin for [vfox](https://vfox.lhan.me/).
 
+Python plugin for [vfox](https://vfox.lhan.me/).
 
 ## Install
 
@@ -9,6 +9,8 @@ After installing [vfox](https://github.com/version-fox/vfox), install the plugin
 ```bash
 vfox add python
 ```
+
+if you want install the free-threaded mode of python, you can select the version ends with `t`, like `v3.14.0a4t`.
 
 ## Mirror
 

--- a/hooks/available.lua
+++ b/hooks/available.lua
@@ -1,4 +1,8 @@
 require("util")
 function PLUGIN:Available(ctx)
-    return parseVersion()
+    if OS_TYPE == "windows" then
+        return parseVersion()
+    else
+        return parseVersionFromPyenv()
+    end
 end

--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -1,10 +1,12 @@
 require("util")
 function PLUGIN:PreInstall(ctx)
     local version = ctx.version
+
     if version == "latest" then
         version = self:Available({})[1].version
     end
-    if not checkIsReleaseVersion(version) then
+
+    if OS_TYPE == "windows" and not checkIsReleaseVersion(version) then
         error("The current version is not released")
         return
     end


### PR DESCRIPTION
close: #20
close: #1 

pull the versions that pyenv supported, also support free-threaded mode.

and will not throw pre-release error

<img width="676" alt="image" src="https://github.com/user-attachments/assets/6bfdd2ed-d9b8-4745-b53e-bc48ae6826df" />

also supported miniconda:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/bdcdf24e-a122-408f-8766-9e409cf12eb3" />
