### PR TITLE
fix: vfox install failure in test workflow

### DIFF
--- a/.github/workflows/vfox-test.yaml
+++ b/.github/workflows/vfox-test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: [3.12.2]
         mirror: ["", "https://mirrors.huaweicloud.com/python/"]
 
@@ -35,7 +35,9 @@ jobs:
       - name: Install vfox
         shell: bash
         run: |
-          curl -sSL https://raw.githubusercontent.com/version-fox/vfox/main/install.sh | bash
+          for i in {1..10}; do
+            curl -sSL https://raw.githubusercontent.com/version-fox/vfox/main/install.sh | bash && break || sleep 5;
+          done
           vfox --version
 
       - name: Install plugin


### PR DESCRIPTION
1. Add retry mechanism when installing VFox

2. Remove macOS runner. (Very frequent network timeouts no macOS)